### PR TITLE
Update ex3.2.py

### DIFF
--- a/Ex_session_03/code/ex3.2/ex3.2.py
+++ b/Ex_session_03/code/ex3.2/ex3.2.py
@@ -11,7 +11,7 @@ def pressureFrom(stringValues):
 
 numOfPatients = len(lines)
 if numOfPatients > 0:
-	maxAveragePressure = 0
+	maxAveragePressure = 0 #no
 	indexOfPatient = 0
 	for i in range(len(lines)):
 		line = lines[i]
@@ -20,7 +20,7 @@ if numOfPatients > 0:
 		if elementsCount > 0:
 			pressures = pressureFrom(elements)
 			#print(pressures)
-			rowAvg = sum(pressures) / (elementsCount-1)
+			rowAvg = float(sum(pressures)) / (elementsCount-1)
 			if rowAvg>maxAveragePressure:
 				maxAveragePressure = rowAvg
 				indexOfPatient = i


### PR DESCRIPTION
perche' la media e' una variabile intera? 
il massimo non si inizializza a 0 ma al valore del primo paziente.